### PR TITLE
Make QTT and VNN optional package extensions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,55 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
+  core:
+    name: Core installation without optional dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.10'
+      - uses: julia-actions/cache@v2
+      - name: Install and load the core package
+        shell: julia --startup-file=no --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.activate(mktempdir())
+          Pkg.develop(path=pwd())
+          Pkg.instantiate()
+
+          optional = Set(["Lux", "Optimisers", "TensorTrainNumerics", "Zygote"])
+          installed = Set(info.name for info in values(Pkg.dependencies()))
+          @assert isempty(intersect(optional, installed))
+
+          using TwoBody
+          @assert Base.get_extension(TwoBody, :TwoBodyQTTExt) === nothing
+          @assert Base.get_extension(TwoBody, :TwoBodyVNNExt) === nothing
+          hamiltonian = TwoBody.Hamiltonian(TwoBody.Kinetic())
+
+          function assert_unavailable(f)
+            try
+              f()
+            catch exception
+              @assert exception isa ArgumentError
+              return
+            end
+            error("optional solver unexpectedly available")
+          end
+
+          assert_unavailable() do
+            TwoBody.solve(
+              hamiltonian,
+              TwoBody.QuanticsTensorTrainMethod(quantics=2),
+            )
+          end
+          assert_unavailable() do
+            TwoBody.solve(hamiltonian, TwoBody.VNN(maxiters=0))
+          end
+
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}

--- a/Project.toml
+++ b/Project.toml
@@ -9,17 +9,23 @@ FiniteDifferenceMatrices = "a7a66f33-e7b8-47af-b618-f9b5bea05f3d"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
-Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Subscripts = "2b7f82d5-8785-4f63-971e-f18ddbeb808e"
+
+[weakdeps]
+Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
+Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 TensorTrainNumerics = "304e70ee-b558-420e-aed5-de4d05b6ca2b"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[extensions]
+TwoBodyQTTExt = "TensorTrainNumerics"
+TwoBodyVNNExt = ["Lux", "Optimisers", "Zygote"]
 
 [compat]
 ArnoldiMethod = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 TwoBody.jl: a Julia package for quantum mechanical two-body problems
 
+QTT and variational-neural-network solvers are optional. Load
+TensorTrainNumerics.jl to activate QTT support, or load Lux.jl, Optimisers.jl,
+and Zygote.jl to activate VNN support. These packages are not installed with the
+TwoBody.jl core.
+
 ## Documentation
 
 - Home: https://juliafewbody.github.io/TwoBody.jl

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,6 +7,8 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 TwoBody = "a92d7657-722c-45a6-9d18-9da4c8a753b6"
+TensorTrainNumerics = "304e70ee-b558-420e-aed5-de4d05b6ca2b"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Antique = "0.15"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,8 @@
 using TwoBody
+import Lux
+import Optimisers
+import TensorTrainNumerics
+import Zygote
 using Documenter
 using DocumenterMermaid
 

--- a/docs/src/QTT.md
+++ b/docs/src/QTT.md
@@ -63,12 +63,19 @@ Thus, when the QTT ranks remain moderate, storage grows as ``O(\log N)`` instead
 
 ## Usage
 
+Install and load TensorTrainNumerics.jl to activate the QTT extension.
+
+```julia
+import Pkg; Pkg.add("TensorTrainNumerics")
+```
+
 For the three-dimensional spherical oscillator in atomic units, configure the QTT
 grid with `quantics`; the number of interior grid points is `2^quantics`. Here a
 coarse grid is used so the example runs quickly.
 
 ```@example qtt
 using TwoBody
+using TensorTrainNumerics
 using Random
 
 Random.seed!(1234)
@@ -152,8 +159,6 @@ organizers for their contributions and support.
 ```@docs; canonical=false
 QuanticsTensorTrainMethod
 solve(hamiltonian::Hamiltonian, method::QuanticsTensorTrainMethod)
-QTTVector
-QTTMatrix
 order
 ranks
 qttvalue

--- a/docs/src/VNN.md
+++ b/docs/src/VNN.md
@@ -17,12 +17,22 @@ E[\psi_\theta] =
 where the grid, Hamiltonian matrix ``\pmb{H}``, and radial Jacobian ``\pmb{J}``
 are provided by `FiniteDifferenceMethod`.
 
+Install and load the optional dependencies to activate the VNN extension.
+
+```julia
+import Pkg; Pkg.add(["Lux", "Optimisers", "Zygote"])
+using Lux, Optimisers, Zygote
+```
+
 ## Standard model
 
 The two-argument `solve` method constructs a Lux network from `architecture`.
 
 ```@example vnn
 using TwoBody
+using Lux
+using Optimisers
+using Zygote
 
 H = Hamiltonian(
   Kinetic(hbar=1, m=1),
@@ -57,6 +67,7 @@ An arbitrary Lux model can be passed explicitly. The model receives radii as a
 using Lux
 using Optimisers
 using Random
+using Zygote
 
 model = Lux.Chain(
   Lux.Dense(1 => 8, tanh),

--- a/ext/TwoBodyQTTExt.jl
+++ b/ext/TwoBodyQTTExt.jl
@@ -1,0 +1,239 @@
+module TwoBodyQTTExt
+
+using TwoBody
+import Logging
+import TensorTrainNumerics
+import TwoBody: PotentialTerm, V, matrix
+
+const QTTVector = TensorTrainNumerics.TTvector
+const QTTMatrix = TensorTrainNumerics.TToperator
+
+TwoBody.order(tt::Union{QTTVector,QTTMatrix}) = tt.N
+TwoBody.ranks(tt::QTTVector) = copy(tt.ttv_rks)
+TwoBody.ranks(tt::QTTMatrix) = copy(tt.tto_rks)
+
+function TwoBody.qttvalue(tt::QTTVector{T}, index::Integer) where {T}
+  n = 1 << TwoBody.order(tt)
+  1 <= index <= n || throw(BoundsError(1:n, index))
+  state = ones(T, 1)
+  index0 = index - 1
+  for site in 1:TwoBody.order(tt)
+    physical = Int((index0 >> (TwoBody.order(tt) - site)) & 1) + 1
+    state = vec(reshape(state, 1, :) * @view(tt.ttv_vec[site][physical, :, :]))
+  end
+  return only(state)
+end
+
+function TwoBody.qttvalue(tt::QTTMatrix{T}, row::Integer, column::Integer) where {T}
+  n = 1 << TwoBody.order(tt)
+  1 <= row <= n || throw(BoundsError(1:n, row))
+  1 <= column <= n || throw(BoundsError(1:n, column))
+  state = ones(T, 1)
+  row0, column0 = row - 1, column - 1
+  for site in 1:TwoBody.order(tt)
+    rowbit = Int((row0 >> (TwoBody.order(tt) - site)) & 1) + 1
+    columnbit = Int((column0 >> (TwoBody.order(tt) - site)) & 1) + 1
+    state = vec(reshape(state, 1, :) * @view(tt.tto_vec[site][rowbit, columnbit, :, :]))
+  end
+  return only(state)
+end
+
+function _qttvector(f::Function, method::QuanticsTensorTrainMethod)
+  q = method.quantics
+  domain = [Float64[0, 1] for _ in 1:q]
+
+  function evaluate(bits::AbstractMatrix)
+    indices = zeros(Int, size(bits, 1))
+    for site in 1:q
+      indices .+= round.(Int, @view(bits[:, site])) .* (1 << (q - site))
+    end
+    return [Float64(f(method.R[index + 1])) for index in indices]
+  end
+
+  algorithm = TensorTrainNumerics.MaxVol(
+    tol=method.tolerance,
+    rmax=method.maxbonddim,
+    maxiter=method.maxiter,
+    verbose=false,
+  )
+  return TensorTrainNumerics.tt_cross(
+    evaluate,
+    domain,
+    algorithm;
+    ranks=min(2, method.maxbonddim),
+    val_size=min(1000, 1 << q),
+  )
+end
+
+function _compress_vector(vector::QTTVector, method::QuanticsTensorTrainMethod)
+  compressed = copy(vector)
+  TensorTrainNumerics.tt_compress!(
+    compressed,
+    method.maxbonddim;
+    truncerr=method.tolerance,
+  )
+  return compressed
+end
+
+function _compress_operator(operator::QTTMatrix, method::QuanticsTensorTrainMethod)
+  fused = TensorTrainNumerics.tto_to_ttv(operator)
+  TensorTrainNumerics.tt_compress!(
+    fused,
+    method.maxoperatorbonddim;
+    truncerr=method.tolerance,
+  )
+  return TensorTrainNumerics.ttv_to_tto(fused)
+end
+
+function matrix(term::Kinetic, method::QuanticsTensorTrainMethod)
+  kinetic = (term.hbar^2 / (2 * term.m * method.Δr^2)) *
+    TensorTrainNumerics.Δ(method.quantics)
+  if method.l == 0
+    return kinetic
+  end
+  centrifugal = _qttvector(
+    r -> term.hbar^2 * method.l * (method.l + 1) / (2 * term.m * r^2),
+    method,
+  )
+  return kinetic + TensorTrainNumerics.ttv_to_diag_tto(centrifugal)
+end
+
+matrix(term::RestEnergy, method::QuanticsTensorTrainMethod) =
+  TensorTrainNumerics.ttv_to_diag_tto(_qttvector(_ -> term.m * term.c^2, method))
+
+const QTTPotentialTerm = Union{Constant,Linear,Coulomb,PowerLaw,Gaussian,Exponential,Yukawa,Custom}
+
+matrix(term::QTTPotentialTerm, method::QuanticsTensorTrainMethod) =
+  TensorTrainNumerics.ttv_to_diag_tto(_qttvector(r -> V(term, r), method))
+
+matrix(term::PotentialTerm, ::QuanticsTensorTrainMethod) =
+  throw(ArgumentError("$(typeof(term)) is not supported by QuanticsTensorTrainMethod"))
+
+function matrix(hamiltonian::Hamiltonian, method::QuanticsTensorTrainMethod)
+  isempty(hamiltonian.terms) && throw(ArgumentError("the Hamiltonian must contain at least one term"))
+  matrices = map(hamiltonian.terms) do term
+    term isa Union{Kinetic,RestEnergy,QTTPotentialTerm} ||
+      throw(ArgumentError("$(typeof(term)) is not supported by QuanticsTensorTrainMethod"))
+    matrix(term, method)
+  end
+  return _compress_operator(reduce(+, matrices), method)
+end
+
+_ttnorm(vector::QTTVector) = TensorTrainNumerics.norm(vector)
+_ttdot(left::QTTVector, right::QTTVector) = TensorTrainNumerics.dot(left, right)
+
+function _dmrg_groundstate(operator::QTTMatrix, guess::QTTVector, method::QuanticsTensorTrainMethod)
+  normalized_guess = guess / _ttnorm(guess)
+  history, state, rank_history = Logging.with_logger(Logging.NullLogger()) do
+    TensorTrainNumerics.dmrg_eigsolve(
+      operator,
+      normalized_guess;
+      N=2,
+      tol=method.tolerance,
+      sweep_schedule=[method.sweeps],
+      rmax_schedule=[method.maxbonddim],
+      it_solver=true,
+      linsolv_maxiter=method.maxiter,
+      linsolv_tol=max(sqrt(method.tolerance), 1e-8),
+    )
+  end
+  state = state / _ttnorm(state)
+  return last(history), state, history, rank_history
+end
+
+function _state_guess(initial::Function, level::Int, method::QuanticsTensorTrainMethod)
+  width = method.rₘₐₓ - method.r₀
+  modulation(r) = level == 0 ? 1.0 : cos(level * π * (r - method.r₀) / width)
+  return _qttvector(r -> r * initial(r) * modulation(r), method)
+end
+
+function _solve_qtt(
+  hamiltonian::Hamiltonian,
+  initial::Function,
+  method::QuanticsTensorTrainMethod;
+  info=4,
+  nₘₐₓ=4,
+)
+  1 <= nₘₐₓ <= (1 << method.quantics) ||
+    throw(ArgumentError("nₘₐₓ must lie between 1 and the number of grid points"))
+
+  H = matrix(hamiltonian, method)
+  deflated = H
+  energies = Float64[]
+  states = QTTVector[]
+  histories = Vector{Float64}[]
+  rank_histories = Vector{Int}[]
+  residuals = Float64[]
+
+  for level in 0:(nₘₐₓ - 1)
+    guess = _state_guess(initial, level, method)
+    _, state, history, rank_history = _dmrg_groundstate(deflated, guess, method)
+
+    Hstate = H * state
+    energy = real(_ttdot(state, Hstate) / _ttdot(state, state))
+    residual = _ttnorm(Hstate - energy * state)
+    push!(energies, energy)
+    push!(states, state)
+    push!(histories, history)
+    push!(rank_histories, rank_history)
+    push!(residuals, residual)
+
+    if level < nₘₐₓ - 1
+      projector = TensorTrainNumerics.outer_product(state, state)
+      deflated = _compress_operator(deflated + method.deflation_shift * projector, method)
+    end
+  end
+
+  overlaps = [_ttdot(states[i], states[j]) for i in eachindex(states), j in eachindex(states)]
+  scale = inv(sqrt(4π * method.Δr))
+  u = [scale * state for state in states]
+  inverse_radius = _qttvector(r -> inv(r), method)
+  ψ = [_compress_vector(TensorTrainNumerics.hadamard(state, inverse_radius), method) for state in u]
+
+  if info > 0
+    println("\n# method\n")
+    println(method)
+    println("\n# eigenvalues\n")
+    for level in 1:min(nₘₐₓ, info)
+      println("E[$level] = $(energies[level])")
+    end
+    println()
+  end
+
+  return info >= 0 ? (
+    hamiltonian=hamiltonian,
+    method=method,
+    nₘₐₓ=nₘₐₓ,
+    H=H,
+    E=energies,
+    C=states,
+    ψ=ψ,
+    u=u,
+    overlaps=overlaps,
+    residuals=residuals,
+    histories=histories,
+    rank_histories=rank_histories,
+  ) : (E=energies,)
+end
+
+function solve_qtt(
+  hamiltonian::Hamiltonian,
+  method::QuanticsTensorTrainMethod;
+  initial=r -> exp(-r),
+  info=4,
+  nₘₐₓ=4,
+)
+  return _solve_qtt(hamiltonian, initial, method; info=info, nₘₐₓ=nₘₐₓ)
+end
+
+function solve_qtt(
+  hamiltonian::Hamiltonian,
+  wavefunction::Function,
+  method::QuanticsTensorTrainMethod;
+  info=4,
+  nₘₐₓ=4,
+)
+  return _solve_qtt(hamiltonian, wavefunction, method; info=info, nₘₐₓ=nₘₐₓ)
+end
+
+end

--- a/ext/TwoBodyVNNExt.jl
+++ b/ext/TwoBodyVNNExt.jl
@@ -1,0 +1,180 @@
+module TwoBodyVNNExt
+
+using TwoBody
+import Lux
+import Optimisers
+import Printf
+import Random
+import Zygote
+import TwoBody: _jacobian, _normalization, _rayleigh_quotient
+
+_resolved_init(method::VariationalNeuralNetwork) =
+  isnothing(method.init) ? Lux.glorot_normal : method.init
+
+_resolved_optimizer(method::VariationalNeuralNetwork) =
+  isnothing(method.optimizer) ? Optimisers.Adam(0.01) : method.optimizer
+
+function _neural_network(method::VariationalNeuralNetwork)
+  dimensions = [1; method.architecture; 1]
+  init = _resolved_init(method)
+  layers = [
+    Lux.Dense(
+      dimensions[index],
+      dimensions[index + 1],
+      method.activation;
+      init_weight=init,
+    ) for index in 1:(length(dimensions) - 1)
+  ]
+  return Lux.Chain(layers...)
+end
+
+_parameter_eltype(x::AbstractArray) = eltype(x)
+_parameter_eltype(x::Number) = typeof(x)
+
+function _parameter_eltype(x::Union{NamedTuple,Tuple})
+  for value in values(x)
+    type = _parameter_eltype(value)
+    isnothing(type) || return type
+  end
+  return nothing
+end
+
+_parameter_eltype(x) = nothing
+
+function _network_input(parameters, R)
+  type = _parameter_eltype(parameters)
+  isnothing(type) && throw(ArgumentError("the Lux model must contain at least one parameter"))
+  type <: Real || throw(ArgumentError("the Lux model parameters must be real-valued"))
+  return reshape(type.(R), 1, :)
+end
+
+function _trial_values(model, parameters, states, input, trial)
+  output, updated_states = Lux.apply(model, input, parameters, states)
+  length(output) == length(input) || throw(DimensionMismatch(
+    "the Lux model must return one wavefunction value for each radial-grid point",
+  ))
+  values = trial.(vec(input), vec(output))
+  eltype(values) <: Real ||
+    throw(ArgumentError("the trial wavefunction must be real-valued"))
+  return values, updated_states
+end
+
+function _validate_trial(values, energy)
+  all(isfinite, values) ||
+    throw(ArgumentError("the trial wavefunction must contain only finite values"))
+  any(value -> !iszero(value), values) ||
+    throw(ArgumentError("the trial wavefunction must not be identically zero"))
+  isfinite(energy) || throw(ArgumentError("the variational energy must be finite"))
+  return nothing
+end
+
+function solve_vnn(
+  hamiltonian::Hamiltonian,
+  method::VariationalNeuralNetwork;
+  kwargs...,
+)
+  return solve_vnn(hamiltonian, _neural_network(method), method; kwargs...)
+end
+
+function solve_vnn(
+  hamiltonian::Hamiltonian,
+  model,
+  method::VariationalNeuralNetwork;
+  rng::Random.AbstractRNG=Random.MersenneTwister(123),
+  parameters=nothing,
+  states=nothing,
+  optimizer_state=nothing,
+  trial=(r, value) -> value,
+  info::Int=0,
+)
+  !isnothing(optimizer_state) && isnothing(parameters) &&
+    throw(ArgumentError("parameters must be supplied with optimizer_state"))
+
+  if isnothing(parameters) || isnothing(states)
+    initialized_parameters, initialized_states = Lux.setup(rng, model)
+    parameters = isnothing(parameters) ? initialized_parameters : parameters
+    states = isnothing(states) ? initialized_states : states
+  end
+
+  fdm = method.fdm
+  H = TwoBody.matrix(hamiltonian, fdm)
+  J = _jacobian(fdm)
+  input = _network_input(parameters, fdm.R)
+
+  values, states = _trial_values(model, parameters, states, input, trial)
+  energy = _rayleigh_quotient(values, H, J)
+  _validate_trial(values, energy)
+
+  history = [energy]
+  optimizer_state = isnothing(optimizer_state) ?
+    Optimisers.setup(_resolved_optimizer(method), parameters) : optimizer_state
+  converged = false
+  stable_steps = 0
+  n_iterations = 0
+
+  if 0 < info
+    println("\n# method\n")
+    println(method)
+    println("\n# optimization\n")
+    Printf.@printf("%9s\t%14s\n", "iteration", "energy")
+    Printf.@printf("%9d\t%+.12e\n", 0, energy)
+  end
+
+  for iteration in 1:method.maxiters
+    gradients = first(Zygote.gradient(parameters) do candidate_parameters
+      candidate_values, _ =
+        _trial_values(model, candidate_parameters, states, input, trial)
+      _rayleigh_quotient(candidate_values, H, J)
+    end)
+    optimizer_state, parameters =
+      Optimisers.update(optimizer_state, parameters, gradients)
+
+    previous_energy = energy
+    values, states = _trial_values(model, parameters, states, input, trial)
+    energy = _rayleigh_quotient(values, H, J)
+    _validate_trial(values, energy)
+    push!(history, energy)
+    n_iterations = iteration
+
+    if abs(energy - previous_energy) <= method.abstol
+      stable_steps += 1
+      converged = method.patience <= stable_steps
+    else
+      stable_steps = 0
+    end
+
+    if 0 < info && (iteration % method.every == 0 || converged || iteration == method.maxiters)
+      Printf.@printf("%9d\t%+.12e\n", iteration, energy)
+    end
+    converged && break
+  end
+
+  normalization = _normalization(values, fdm, J)
+  normalized_values = normalization * values
+  parameter_type = _parameter_eltype(parameters)
+  wavefunction = function (r::Real)
+    scalar_input = reshape(parameter_type[r], 1, 1)
+    output, _ = Lux.apply(model, scalar_input, parameters, states)
+    return normalization * trial(r, only(output))
+  end
+
+  return (
+    hamiltonian=hamiltonian,
+    method=method,
+    model=model,
+    parameters=parameters,
+    states=states,
+    optimizer_state=optimizer_state,
+    H=H,
+    J=J,
+    E=energy,
+    ψ=normalized_values,
+    raw_ψ=values,
+    wavefunction=wavefunction,
+    history=history,
+    n_iterations=n_iterations,
+    converged=converged,
+  )
+end
+
+end

--- a/src/QTT.jl
+++ b/src/QTT.jl
@@ -1,21 +1,13 @@
-export QuanticsTensorTrainMethod, QTTVector, QTTMatrix, order, ranks, qttvalue
-
-import LinearAlgebra
-import Logging
-import TensorTrainNumerics
-
-"A vector stored as a quantics tensor train."
-const QTTVector = TensorTrainNumerics.TTvector
-
-"A matrix stored as a quantics tensor train / matrix product operator."
-const QTTMatrix = TensorTrainNumerics.TToperator
+export QuanticsTensorTrainMethod, order, ranks, qttvalue
 
 "Return the number of binary sites in a QTT."
-order(tt::Union{QTTVector,QTTMatrix}) = tt.N
+function order end
 
 "Return the left boundary, internal, and right boundary ranks of a QTT."
-ranks(tt::QTTVector) = copy(tt.ttv_rks)
-ranks(tt::QTTMatrix) = copy(tt.tto_rks)
+function ranks end
+
+"Contract a QTT at one vector or matrix index without materializing its entries."
+function qttvalue end
 
 struct QuanticsTensorTrainMethod
   quantics::Int
@@ -80,208 +72,20 @@ Base.string(method::QuanticsTensorTrainMethod) =
          :maxoperatorbonddim, :maxiter, :sweeps, :deflation_shift)], ", ") * ")"
 Base.show(io::IO, method::QuanticsTensorTrainMethod) = print(io, string(method))
 
-function qttvalue(tt::QTTVector{T}, index::Integer) where {T}
-  n = 1 << order(tt)
-  1 <= index <= n || throw(BoundsError(1:n, index))
-  state = ones(T, 1)
-  index0 = index - 1
-  for site in 1:order(tt)
-    physical = Int((index0 >> (order(tt) - site)) & 1) + 1
-    state = vec(reshape(state, 1, :) * @view(tt.ttv_vec[site][physical, :, :]))
-  end
-  return only(state)
+function _qtt_unavailable()
+  throw(ArgumentError(
+    "QTT support requires TensorTrainNumerics.jl. Run " *
+    "`Pkg.add(\"TensorTrainNumerics\")`, then load it with " *
+    "`using TensorTrainNumerics`.",
+  ))
 end
 
-function qttvalue(tt::QTTMatrix{T}, row::Integer, column::Integer) where {T}
-  n = 1 << order(tt)
-  1 <= row <= n || throw(BoundsError(1:n, row))
-  1 <= column <= n || throw(BoundsError(1:n, column))
-  state = ones(T, 1)
-  row0, column0 = row - 1, column - 1
-  for site in 1:order(tt)
-    rowbit = Int((row0 >> (order(tt) - site)) & 1) + 1
-    columnbit = Int((column0 >> (order(tt) - site)) & 1) + 1
-    state = vec(reshape(state, 1, :) * @view(tt.tto_vec[site][rowbit, columnbit, :, :]))
-  end
-  return only(state)
-end
+matrix(::Any, ::QuanticsTensorTrainMethod) = _qtt_unavailable()
 
-function _qttvector(f::Function, method::QuanticsTensorTrainMethod)
-  q = method.quantics
-  domain = [Float64[0, 1] for _ in 1:q]
-
-  function evaluate(bits::AbstractMatrix)
-    indices = zeros(Int, size(bits, 1))
-    for site in 1:q
-      indices .+= round.(Int, @view(bits[:, site])) .* (1 << (q - site))
-    end
-    return [Float64(f(method.R[index + 1])) for index in indices]
-  end
-
-  algorithm = TensorTrainNumerics.MaxVol(
-    tol=method.tolerance,
-    rmax=method.maxbonddim,
-    maxiter=method.maxiter,
-    verbose=false,
-  )
-  return TensorTrainNumerics.tt_cross(
-    evaluate,
-    domain,
-    algorithm;
-    ranks=min(2, method.maxbonddim),
-    val_size=min(1000, 1 << q),
-  )
-end
-
-function _compress_vector(vector::QTTVector, method::QuanticsTensorTrainMethod)
-  compressed = copy(vector)
-  TensorTrainNumerics.tt_compress!(
-    compressed,
-    method.maxbonddim;
-    truncerr=method.tolerance,
-  )
-  return compressed
-end
-
-function _compress_operator(operator::QTTMatrix, method::QuanticsTensorTrainMethod)
-  fused = TensorTrainNumerics.tto_to_ttv(operator)
-  TensorTrainNumerics.tt_compress!(
-    fused,
-    method.maxoperatorbonddim;
-    truncerr=method.tolerance,
-  )
-  return TensorTrainNumerics.ttv_to_tto(fused)
-end
-
-function matrix(term::Kinetic, method::QuanticsTensorTrainMethod)
-  kinetic = (term.hbar^2 / (2 * term.m * method.Δr^2)) *
-    TensorTrainNumerics.Δ(method.quantics)
-  if method.l == 0
-    return kinetic
-  end
-  centrifugal = _qttvector(
-    r -> term.hbar^2 * method.l * (method.l + 1) / (2 * term.m * r^2),
-    method,
-  )
-  return kinetic + TensorTrainNumerics.ttv_to_diag_tto(centrifugal)
-end
-
-matrix(term::RestEnergy, method::QuanticsTensorTrainMethod) =
-  TensorTrainNumerics.ttv_to_diag_tto(_qttvector(_ -> term.m * term.c^2, method))
-
-const QTTPotentialTerm = Union{Constant,Linear,Coulomb,PowerLaw,Gaussian,Exponential,Yukawa,Custom}
-
-matrix(term::QTTPotentialTerm, method::QuanticsTensorTrainMethod) =
-  TensorTrainNumerics.ttv_to_diag_tto(_qttvector(r -> V(term, r), method))
-
-matrix(term::PotentialTerm, ::QuanticsTensorTrainMethod) =
-  throw(ArgumentError("$(typeof(term)) is not supported by QuanticsTensorTrainMethod"))
-
-function matrix(hamiltonian::Hamiltonian, method::QuanticsTensorTrainMethod)
-  isempty(hamiltonian.terms) && throw(ArgumentError("the Hamiltonian must contain at least one term"))
-  matrices = map(hamiltonian.terms) do term
-    term isa Union{Kinetic,RestEnergy,QTTPotentialTerm} ||
-      throw(ArgumentError("$(typeof(term)) is not supported by QuanticsTensorTrainMethod"))
-    matrix(term, method)
-  end
-  return _compress_operator(reduce(+, matrices), method)
-end
-
-_ttnorm(vector::QTTVector) = TensorTrainNumerics.norm(vector)
-_ttdot(left::QTTVector, right::QTTVector) = TensorTrainNumerics.dot(left, right)
-
-function _dmrg_groundstate(operator::QTTMatrix, guess::QTTVector, method::QuanticsTensorTrainMethod)
-  normalized_guess = guess / _ttnorm(guess)
-  history, state, rank_history = Logging.with_logger(Logging.NullLogger()) do
-    TensorTrainNumerics.dmrg_eigsolve(
-      operator,
-      normalized_guess;
-      N=2,
-      tol=method.tolerance,
-      sweep_schedule=[method.sweeps],
-      rmax_schedule=[method.maxbonddim],
-      it_solver=true,
-      linsolv_maxiter=method.maxiter,
-      linsolv_tol=max(sqrt(method.tolerance), 1e-8),
-    )
-  end
-  state = state / _ttnorm(state)
-  return last(history), state, history, rank_history
-end
-
-function _state_guess(initial::Function, level::Int, method::QuanticsTensorTrainMethod)
-  width = method.rₘₐₓ - method.r₀
-  modulation(r) = level == 0 ? 1.0 : cos(level * π * (r - method.r₀) / width)
-  return _qttvector(r -> r * initial(r) * modulation(r), method)
-end
-
-function _solve_qtt(
-  hamiltonian::Hamiltonian,
-  initial::Function,
-  method::QuanticsTensorTrainMethod;
-  info=4,
-  nₘₐₓ=4,
-)
-  1 <= nₘₐₓ <= (1 << method.quantics) ||
-    throw(ArgumentError("nₘₐₓ must lie between 1 and the number of grid points"))
-
-  H = matrix(hamiltonian, method)
-  deflated = H
-  energies = Float64[]
-  states = QTTVector[]
-  histories = Vector{Float64}[]
-  rank_histories = Vector{Int}[]
-  residuals = Float64[]
-
-  for level in 0:(nₘₐₓ - 1)
-    guess = _state_guess(initial, level, method)
-    _, state, history, rank_history = _dmrg_groundstate(deflated, guess, method)
-
-    Hstate = H * state
-    energy = real(_ttdot(state, Hstate) / _ttdot(state, state))
-    residual = _ttnorm(Hstate - energy * state)
-    push!(energies, energy)
-    push!(states, state)
-    push!(histories, history)
-    push!(rank_histories, rank_history)
-    push!(residuals, residual)
-
-    if level < nₘₐₓ - 1
-      projector = TensorTrainNumerics.outer_product(state, state)
-      deflated = _compress_operator(deflated + method.deflation_shift * projector, method)
-    end
-  end
-
-  overlaps = [_ttdot(states[i], states[j]) for i in eachindex(states), j in eachindex(states)]
-  scale = inv(sqrt(4π * method.Δr))
-  u = [scale * state for state in states]
-  inverse_radius = _qttvector(r -> inv(r), method)
-  ψ = [_compress_vector(TensorTrainNumerics.hadamard(state, inverse_radius), method) for state in u]
-
-  if info > 0
-    println("\n# method\n")
-    println(method)
-    println("\n# eigenvalues\n")
-    for level in 1:min(nₘₐₓ, info)
-      println("E[$level] = $(energies[level])")
-    end
-    println()
-  end
-
-  return info >= 0 ? (
-    hamiltonian=hamiltonian,
-    method=method,
-    nₘₐₓ=nₘₐₓ,
-    H=H,
-    E=energies,
-    C=states,
-    ψ=ψ,
-    u=u,
-    overlaps=overlaps,
-    residuals=residuals,
-    histories=histories,
-    rank_histories=rank_histories,
-  ) : (E=energies,)
+function _qtt_extension()
+  extension = Base.get_extension(@__MODULE__, :TwoBodyQTTExt)
+  isnothing(extension) && _qtt_unavailable()
+  return extension
 end
 
 function solve(
@@ -291,7 +95,13 @@ function solve(
   info=4,
   nₘₐₓ=4,
 )
-  return _solve_qtt(hamiltonian, initial, method; info=info, nₘₐₓ=nₘₐₓ)
+  return _qtt_extension().solve_qtt(
+    hamiltonian,
+    method;
+    initial=initial,
+    info=info,
+    nₘₐₓ=nₘₐₓ,
+  )
 end
 
 function solve(
@@ -301,7 +111,13 @@ function solve(
   info=4,
   nₘₐₓ=4,
 )
-  return _solve_qtt(hamiltonian, wavefunction, method; info=info, nₘₐₓ=nₘₐₓ)
+  return _qtt_extension().solve_qtt(
+    hamiltonian,
+    wavefunction,
+    method;
+    info=info,
+    nₘₐₓ=nₘₐₓ,
+  )
 end
 
 @doc raw"""
@@ -325,13 +141,11 @@ boundaries. `maxbonddim` and `maxoperatorbonddim` bound state and MPO ranks;
 Compute the lowest `nₘₐₓ` QTT eigenstates. `initial` seeds the first DMRG solve;
 `info` controls progress output. The result contains energies `E`, unit-norm tensor
 trains `C`, radial functions `ψ` and `u`, and the diagnostics `overlaps`, `residuals`,
-`histories`, and `rank_histories`. Each energy is evaluated with the original
-Hamiltonian rather than its deflated counterpart.
-""" solve(hamiltonian::Hamiltonian, method::QuanticsTensorTrainMethod; initial=r -> exp(-r), info=4, nₘₐₓ=4)
-
-@doc raw"""
-    qttvalue(tt::QTTVector, index)
-    qttvalue(tt::QTTMatrix, row, column)
-
-Contract a QTT at one vector or matrix index without materializing its ``2^q`` entries.
-""" qttvalue
+`histories`, and `rank_histories`.
+""" solve(
+  hamiltonian::Hamiltonian,
+  method::QuanticsTensorTrainMethod;
+  initial=r -> exp(-r),
+  info=4,
+  nₘₐₓ=4,
+)

--- a/src/VNN.jl
+++ b/src/VNN.jl
@@ -1,10 +1,6 @@
 export VariationalNeuralNetwork, VNN
 
-import Lux
-import Optimisers
-import Printf
 import Random
-import Zygote
 
 _softplus(x) = max(x, zero(x)) + log1p(exp(-abs(x)))
 
@@ -29,8 +25,8 @@ struct VariationalNeuralNetwork{F<:FiniteDifferenceMethod,A,I,O,T<:AbstractFloat
     solver::Union{Nothing,Symbol}=nothing,
     architecture::AbstractVector{<:Integer}=[2],
     activation=_softplus,
-    init=Lux.glorot_normal,
-    optimizer=Optimisers.Adam(0.01),
+    init=nothing,
+    optimizer=nothing,
     maxiters::Int=1_000,
     abstol::Real=1e-8,
     patience::Int=10,
@@ -105,57 +101,18 @@ Base.string(method::VariationalNeuralNetwork) =
   ")"
 Base.show(io::IO, method::VariationalNeuralNetwork) = print(io, Base.string(method))
 
-function _neural_network(method::VariationalNeuralNetwork)
-  dimensions = [1; method.architecture; 1]
-  layers = [
-    Lux.Dense(
-      dimensions[index],
-      dimensions[index + 1],
-      method.activation;
-      init_weight=method.init,
-    ) for index in 1:(length(dimensions) - 1)
-  ]
-  return Lux.Chain(layers...)
-end
-
-_parameter_eltype(x::AbstractArray) = eltype(x)
-_parameter_eltype(x::Number) = typeof(x)
-
-function _parameter_eltype(x::Union{NamedTuple,Tuple})
-  for value in values(x)
-    type = _parameter_eltype(value)
-    isnothing(type) || return type
-  end
-  return nothing
-end
-
-_parameter_eltype(x) = nothing
-
-function _network_input(parameters, R)
-  type = _parameter_eltype(parameters)
-  isnothing(type) && throw(ArgumentError("the Lux model must contain at least one parameter"))
-  type <: Real || throw(ArgumentError("the Lux model parameters must be real-valued"))
-  return reshape(type.(R), 1, :)
-end
-
-function _trial_values(model, parameters, states, input, trial)
-  output, updated_states = Lux.apply(model, input, parameters, states)
-  length(output) == length(input) || throw(DimensionMismatch(
-    "the Lux model must return one wavefunction value for each radial-grid point",
+function _vnn_unavailable()
+  throw(ArgumentError(
+    "VNN support requires Lux.jl, Optimisers.jl, and Zygote.jl. Run " *
+    "`Pkg.add([\"Lux\", \"Optimisers\", \"Zygote\"])`, then load them with " *
+    "`using Lux, Optimisers, Zygote`.",
   ))
-  values = trial.(vec(input), vec(output))
-  eltype(values) <: Real ||
-    throw(ArgumentError("the trial wavefunction must be real-valued"))
-  return values, updated_states
 end
 
-function _validate_trial(values, energy)
-  all(isfinite, values) ||
-    throw(ArgumentError("the trial wavefunction must contain only finite values"))
-  any(value -> !iszero(value), values) ||
-    throw(ArgumentError("the trial wavefunction must not be identically zero"))
-  isfinite(energy) || throw(ArgumentError("the variational energy must be finite"))
-  return nothing
+function _vnn_extension()
+  extension = Base.get_extension(@__MODULE__, :TwoBodyVNNExt)
+  isnothing(extension) && _vnn_unavailable()
+  return extension
 end
 
 function solve(
@@ -163,7 +120,7 @@ function solve(
   method::VariationalNeuralNetwork;
   kwargs...,
 )
-  return solve(hamiltonian, _neural_network(method), method; kwargs...)
+  return _vnn_extension().solve_vnn(hamiltonian, method; kwargs...)
 end
 
 function solve(
@@ -177,110 +134,34 @@ function solve(
   trial=(r, value) -> value,
   info::Int=0,
 )
-  !isnothing(optimizer_state) && isnothing(parameters) &&
-    throw(ArgumentError("parameters must be supplied with optimizer_state"))
-
-  if isnothing(parameters) || isnothing(states)
-    initialized_parameters, initialized_states = Lux.setup(rng, model)
-    parameters = isnothing(parameters) ? initialized_parameters : parameters
-    states = isnothing(states) ? initialized_states : states
-  end
-
-  fdm = method.fdm
-  H = matrix(hamiltonian, fdm)
-  J = _jacobian(fdm)
-  input = _network_input(parameters, fdm.R)
-
-  values, states = _trial_values(model, parameters, states, input, trial)
-  energy = _rayleigh_quotient(values, H, J)
-  _validate_trial(values, energy)
-
-  history = [energy]
-  optimizer_state = isnothing(optimizer_state) ?
-    Optimisers.setup(method.optimizer, parameters) : optimizer_state
-  converged = false
-  stable_steps = 0
-  n_iterations = 0
-
-  if 0 < info
-    println("\n# method\n")
-    println(method)
-    println("\n# optimization\n")
-    Printf.@printf("%9s\t%14s\n", "iteration", "energy")
-    Printf.@printf("%9d\t%+.12e\n", 0, energy)
-  end
-
-  for iteration in 1:method.maxiters
-    gradients = first(Zygote.gradient(parameters) do candidate_parameters
-      candidate_values, _ =
-        _trial_values(model, candidate_parameters, states, input, trial)
-      _rayleigh_quotient(candidate_values, H, J)
-    end)
-    optimizer_state, parameters =
-      Optimisers.update(optimizer_state, parameters, gradients)
-
-    previous_energy = energy
-    values, states = _trial_values(model, parameters, states, input, trial)
-    energy = _rayleigh_quotient(values, H, J)
-    _validate_trial(values, energy)
-    push!(history, energy)
-    n_iterations = iteration
-
-    if abs(energy - previous_energy) <= method.abstol
-      stable_steps += 1
-      converged = method.patience <= stable_steps
-    else
-      stable_steps = 0
-    end
-
-    if 0 < info && (iteration % method.every == 0 || converged || iteration == method.maxiters)
-      Printf.@printf("%9d\t%+.12e\n", iteration, energy)
-    end
-    converged && break
-  end
-
-  normalization = _normalization(values, fdm, J)
-  normalized_values = normalization * values
-  parameter_type = _parameter_eltype(parameters)
-  wavefunction = function (r::Real)
-    scalar_input = reshape(parameter_type[r], 1, 1)
-    output, _ = Lux.apply(model, scalar_input, parameters, states)
-    return normalization * trial(r, only(output))
-  end
-
-  return (
-    hamiltonian=hamiltonian,
-    method=method,
-    model=model,
+  return _vnn_extension().solve_vnn(
+    hamiltonian,
+    model,
+    method;
+    rng=rng,
     parameters=parameters,
     states=states,
     optimizer_state=optimizer_state,
-    H=H,
-    J=J,
-    E=energy,
-    ψ=normalized_values,
-    raw_ψ=values,
-    wavefunction=wavefunction,
-    history=history,
-    n_iterations=n_iterations,
-    converged=converged,
+    trial=trial,
+    info=info,
   )
 end
 
 @doc raw"""
-`VariationalNeuralNetwork(; fdm=nothing, Δr=nothing, rₘₐₓ=nothing, R=nothing, l=nothing, direction=nothing, solver=nothing, architecture=[2], activation=softplus, init=Lux.glorot_normal, optimizer=Optimisers.Adam(0.01), maxiters=1000, abstol=1e-8, patience=10, every=100)`
+    VariationalNeuralNetwork(; fdm=nothing, Δr=nothing, rₘₐₓ=nothing,
+      R=nothing, l=nothing, direction=nothing, solver=nothing,
+      architecture=[2], activation=softplus, init=nothing, optimizer=nothing,
+      maxiters=1000, abstol=1e-8, patience=10, every=100)
 
 Options for optimizing a Lux neural network as a radial trial wavefunction.
-`VNN` is an abbreviation for `VariationalNeuralNetwork`.
-
-Pass an existing `FiniteDifferenceMethod` as `fdm`, or use the finite-difference
-keywords directly. `architecture` defines the hidden-layer widths of the
-standard Lux model used by `solve(hamiltonian, method)`. A custom Lux model can
-instead be supplied with `solve(hamiltonian, model, method)`.
+`VNN` is an abbreviation for `VariationalNeuralNetwork`. VNN support is activated
+by loading Lux.jl, Optimisers.jl, and Zygote.jl. If `init` or `optimizer` is
+`nothing`, the extension uses `Lux.glorot_normal` or `Optimisers.Adam(0.01)`,
+respectively.
 """ VariationalNeuralNetwork
 
 @doc raw"""
-`solve(hamiltonian, method::VariationalNeuralNetwork; kwargs...)`
+    solve(hamiltonian, method::VariationalNeuralNetwork; kwargs...)
 
 Build the standard Lux model specified by `method.architecture` and minimize its
 finite-difference Rayleigh quotient. See the three-argument overload to supply a
@@ -288,24 +169,14 @@ custom Lux model.
 """ solve(hamiltonian::Hamiltonian, method::VariationalNeuralNetwork; kwargs...)
 
 @doc raw"""
-`solve(hamiltonian, model, method::VariationalNeuralNetwork; rng=Random.MersenneTwister(123), parameters=nothing, states=nothing, optimizer_state=nothing, trial=(r, value) -> value, info=0)`
+    solve(hamiltonian, model, method::VariationalNeuralNetwork;
+          rng=Random.MersenneTwister(123), parameters=nothing, states=nothing,
+          optimizer_state=nothing, trial=(r, value) -> value, info=0)
 
-Minimize the finite-difference Rayleigh quotient
-
-```math
-E[\psi_\theta] =
-\frac{\pmb{\psi}_\theta^\mathsf{T}\pmb{J}\pmb{H}\pmb{\psi}_\theta}
-     {\pmb{\psi}_\theta^\mathsf{T}\pmb{J}\pmb{\psi}_\theta}
-```
-
-with respect to the parameters of a Lux model. The model receives the complete
-radial grid as a batch and must return one real value per grid point. `trial`
-can impose an envelope or boundary condition on the raw output. Pass returned
-`parameters`, `states`, and optionally `optimizer_state` to continue training.
-
-The result contains the energy `E`, normalized grid values `ψ`, raw values
-`raw_ψ`, a callable `wavefunction`, Lux variables, optimizer state, energy
-`history`, `n_iterations`, and `converged`.
+Minimize the finite-difference Rayleigh quotient with respect to the parameters of
+a Lux model. The model receives the complete radial grid as a batch and must return
+one real value per grid point. Pass returned `parameters`, `states`, and optionally
+`optimizer_state` to continue training.
 """ solve(
   hamiltonian::Hamiltonian,
   model,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,7 +7,9 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+TensorTrainNumerics = "304e70ee-b558-420e-aed5-de4d05b6ca2b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Antique = "0.15"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,8 @@
 using TwoBody
+import Lux
+import Optimisers
+import TensorTrainNumerics
+import Zygote
 using Test
 using QuadGK
 using Printf


### PR DESCRIPTION
## Summary

- move Lux, Optimisers, TensorTrainNumerics, and Zygote from regular dependencies to weak dependencies
- load the QTT and VNN implementations through Julia package extensions
- keep the public solver configuration types and `solve` entry points in the lightweight TwoBody core
- update tests, documentation, and CI for explicit optional-dependency activation

## User-facing behavior

Installing or loading TwoBody no longer installs or precompiles the QTT/VNN dependency stacks.

QTT support is activated with:

```julia
import Pkg; Pkg.add("TensorTrainNumerics")
using TwoBody, TensorTrainNumerics
```

VNN support is activated with:

```julia
import Pkg; Pkg.add(["Lux", "Optimisers", "Zygote"])
using TwoBody, Lux, Optimisers, Zygote
```

`QTTVector` and `QTTMatrix` are no longer exported aliases from TwoBody because their concrete types belong to the optional TensorTrainNumerics dependency. QTT solver return values remain TensorTrainNumerics tensor-train types.

## Validation

- fresh Julia 1.10.12 core environment contains none of the four optional packages
- full test suite: 551/551 passed
- focused extension tests: QTT 82/82 and VNN 37/37 passed after the final facade refactor
- local Documenter build completed successfully

---
This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.