### PR TITLE
Restore Codecov, update workflows, and speed up basis tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,11 +19,11 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Install and load the core package
         shell: julia --startup-file=no --color=yes {0}
         run: |
@@ -68,6 +68,7 @@ jobs:
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
       contents: read
+      id-token: write # authenticate Codecov uploads with GitHub OIDC
     strategy:
       fail-fast: false
       matrix:
@@ -79,14 +80,28 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: ${{ matrix.version == '1.10' }}
+      - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.version == '1.10'
+        with:
+          directories: src,ext
+      - uses: codecov/codecov-action@v5
+        if: matrix.version == '1.10'
+        with:
+          files: lcov.info
+          disable_search: true
+          # Fork pull requests use Codecov's tokenless upload support.
+          use_oidc: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          fail_ci_if_error: true
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -95,11 +110,11 @@ jobs:
       contents: write
       statuses: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Configure doc environment
         shell: julia --project=docs --color=yes {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,12 +15,13 @@ jobs:
   core:
     name: Core installation without optional dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1.10'
       - uses: julia-actions/cache@v3
@@ -69,6 +70,9 @@ jobs:
       actions: write
       contents: read
       id-token: write # authenticate Codecov uploads with GitHub OIDC
+    env:
+      # Fork and Dependabot runs cannot rely on a writable OIDC token.
+      CODECOV_USE_OIDC: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     strategy:
       fail-fast: false
       matrix:
@@ -80,8 +84,8 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -94,24 +98,26 @@ jobs:
         if: matrix.version == '1.10'
         with:
           directories: src,ext
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         if: matrix.version == '1.10'
+        # Keep upload/service failures from blocking fork and Dependabot PRs.
+        continue-on-error: ${{ env.CODECOV_USE_OIDC != 'true' }}
         with:
           files: lcov.info
           disable_search: true
-          # Fork pull requests use Codecov's tokenless upload support.
-          use_oidc: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-          fail_ci_if_error: true
+          use_oidc: ${{ env.CODECOV_USE_OIDC == 'true' }}
+          fail_ci_if_error: ${{ env.CODECOV_USE_OIDC == 'true' }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: write # needed to allow julia-actions/cache to proactively delete old caches that it has created
       contents: write
       statuses: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
       - uses: julia-actions/cache@v3

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,11 +6,19 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - name: Install CompatHelper
+        shell: julia --startup-file=no --color=yes {0}
+        run: using Pkg; Pkg.add(PackageSpec(name="CompatHelper", version="3"))
+      - name: Run CompatHelper
+        shell: julia --startup-file=no --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        run: using CompatHelper; CompatHelper.main()

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,19 +6,27 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
       - name: Install CompatHelper
         shell: julia --startup-file=no --color=yes {0}
-        run: using Pkg; Pkg.add(PackageSpec(name="CompatHelper", version="3"))
+        run: |
+          using Pkg
+          Pkg.activate(joinpath(ENV["RUNNER_TEMP"], "compathelper"))
+          Pkg.add(PackageSpec(name="CompatHelper", version="3"))
       - name: Run CompatHelper
         shell: julia --startup-file=no --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: using CompatHelper; CompatHelper.main()
+        run: |
+          using Pkg
+          Pkg.activate(joinpath(ENV["RUNNER_TEMP"], "compathelper"))
+          using CompatHelper
+          CompatHelper.main()

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -1,0 +1,28 @@
+name: Runic formatting
+on:
+  workflow_dispatch:
+jobs:
+  runic:
+    name: Runic
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'
+          format_files: true
+      - name: Save formatting patch
+        if: ${{ !cancelled() }}
+        run: git diff --binary --output=runic.patch
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: runic-formatting-patch
+          path: runic.patch
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -5,22 +5,29 @@ jobs:
   runic:
     name: Runic
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
       - uses: fredrikekre/runic-action@v1
+        id: runic
         with:
           version: '1'
           format_files: true
       - name: Save formatting patch
-        if: ${{ !cancelled() }}
-        run: git diff --binary --output=runic.patch
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        id: patch
+        if: ${{ !cancelled() && steps.runic.outcome == 'failure' }}
+        run: |
+          git diff --binary --output=runic.patch
+          if test -s runic.patch; then
+            echo 'has_changes=true' >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() && steps.patch.outputs.has_changes == 'true' }}
         with:
           name: runic-formatting-patch
           path: runic.patch

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -8,8 +8,15 @@ jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create tags and GitHub releases
+      issues: write # report releases that require manual intervention
+      pull-requests: read # include pull requests in changelogs
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # SSH enables tag-triggered CI. GitHub releases for commits that modify
+          # workflows may still require a PAT with workflow scope or manual creation:
+          # https://github.com/JuliaRegistries/TagBot#commits-that-modify-workflow-files
           ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -8,6 +8,7 @@ jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write # create tags and GitHub releases
       issues: write # report releases that require manual intervention

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -69,6 +69,33 @@ This is the typical workflow for making changes.
 
 8. Submit a pull request on GitHub.
 
+## GitHub Actions
+
+CI tests Julia 1.10 and 1.12, checks installation without optional solver dependencies,
+and builds the documentation. The Julia 1.10 test job collects coverage for `src` and
+`ext`, converts it to `lcov.info`, and uploads it to Codecov. Pushes and pull requests
+from this repository authenticate using GitHub OIDC; no `CODECOV_TOKEN` secret is
+needed. Fork pull requests use Codecov's tokenless upload support. Upload errors fail
+the job so that a broken integration is visible.
+
+To check formatting, run **Runic formatting** from the repository's Actions tab and
+select the branch to check. The workflow reports formatting differences as a failed
+check and saves a `runic-formatting-patch` artifact. Download and extract the artifact,
+then apply `runic.patch` with `git apply runic.patch` in a checkout of the same commit.
+Review and commit the changes as usual. Formatting runs only on manual dispatch.
+
+CompatHelper runs daily and can also be dispatched manually. In **Settings > Actions >
+General**, enable **Allow GitHub Actions to create and approve pull requests** so that
+it can open dependency updates. If GitHub disables its schedule after repository
+inactivity, re-enable the workflow in the Actions tab. The workflow uses
+`DOCUMENTER_KEY` as `COMPATHELPER_PRIV` so its pull requests can trigger CI.
+
+TagBot uses `GITHUB_TOKEN` to create releases and `DOCUMENTER_KEY` to push tags that
+trigger documentation builds. The key must be configured as a deploy key with write
+access. Releases for commits that modify workflow files may require manual creation
+or a personal access token with workflow scope; see the
+[TagBot troubleshooting guide](https://github.com/JuliaRegistries/TagBot#commits-that-modify-workflow-files).
+
 ## Adding New Operators and Solvers
 
 TwoBody.jl uses Julia's multiple dispatch to keep the physical problem separate from its numerical solution.

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -73,14 +73,19 @@ This is the typical workflow for making changes.
 
 CI tests Julia 1.10 and 1.12, checks installation without optional solver dependencies,
 and builds the documentation. The Julia 1.10 test job collects coverage for `src` and
-`ext`, converts it to `lcov.info`, and uploads it to Codecov. Pushes and pull requests
-from this repository authenticate using GitHub OIDC; no `CODECOV_TOKEN` secret is
-needed. Fork pull requests use Codecov's tokenless upload support. Upload errors fail
-the job so that a broken integration is visible.
+`ext`, converts it to `lcov.info`, and uploads it to Codecov. Repository builds other
+than Dependabot runs authenticate using GitHub OIDC; no `CODECOV_TOKEN` secret is
+needed. Upload errors fail these jobs so that a broken integration is visible.
+Fork and Dependabot runs attempt tokenless uploads without OIDC; failures in the
+upload step do not fail their test jobs. Test and coverage-generation failures still
+fail CI. Codecov's action handles public fork PRs using prefixed branch names, so
+organization-wide token authentication can remain enabled; see
+[Codecov's token documentation](https://docs.codecov.com/docs/codecov-tokens#commits-on-unprotected-branches).
 
 To check formatting, run **Runic formatting** from the repository's Actions tab and
 select the branch to check. The workflow reports formatting differences as a failed
-check and saves a `runic-formatting-patch` artifact. Download and extract the artifact,
+check and saves a `runic-formatting-patch` artifact only when the patch is nonempty.
+Download and extract the artifact,
 then apply `runic.patch` with `git apply runic.patch` in a checkout of the same commit.
 Review and commit the changes as usual. Formatting runs only on manual dispatch.
 

--- a/test/Basis.jl
+++ b/test/Basis.jl
@@ -1,3 +1,27 @@
+# Tensor-product quadrature avoids compiling three nested adaptive integrators.
+# These orders resolve all exponents, momenta, and directions checked below.
+function gaussian_fourier_integral(b, k, θk, φk)
+  radial_nodes, radial_weights = QuadGK.gauss(192)
+  polar_nodes, polar_weights = QuadGK.gauss(64)
+  azimuthal_nodes, azimuthal_weights = QuadGK.gauss(64)
+  integral = 0.0im
+  for (x, wx) in zip(radial_nodes, radial_weights)
+    # Map [-1, 1] to [0, ∞) with r = t / (1 - t), t = (x + 1) / 2.
+    t = (x + 1) / 2
+    r = t / (1 - t)
+    radial_factor = wx / (2 * (1 - t)^2) * TwoBody.φ(b, r) * r^2
+    for (y, wy) in zip(polar_nodes, polar_weights)
+      θ = π * (y + 1) / 2
+      polar_factor = wy * π / 2 * sin(θ)
+      for (z, wz) in zip(azimuthal_nodes, azimuthal_weights)
+        φ = π * (z + 1)
+        integral += radial_factor * polar_factor * wz * π * TwoBody.expikr(k, θk, φk, r, θ, φ)
+      end
+    end
+  end
+  return abs((2π)^(-3/2) * integral)
+end
+
 @testset "Basis.jl" begin
 
   BS = BasisSet(
@@ -74,15 +98,7 @@
     for k in [0.0, 3.0, 5.0]
     for θk in [0.0, 0.5]
     for φk in [0.0, 1.0]
-      numerical = abs(
-        quadgk(φ ->
-        quadgk(θ ->
-        quadgk(r ->
-          (2π)^(-3/2) * TwoBody.φ(b,r) * TwoBody.expikr(k,θk,φk,r,θ,φ) * r^2 * sin(θ)
-        , 0, Inf, maxevals=100)[1]
-        , 0,   π, maxevals=20)[1]
-        , 0,  2π, maxevals=40)[1]
-      )
+      numerical = gaussian_fourier_integral(b, k, θk, φk)
       analytical = exp(-k^2/4/a) / (2*a)^(3/2)
       acceptance = abs(analytical)<1e-5 ? isapprox(analytical, numerical, atol=1e-2) : isapprox(analytical, numerical, rtol=1e-2)
       @test acceptance

--- a/test/Basis.jl
+++ b/test/Basis.jl
@@ -1,25 +1,11 @@
-# Tensor-product quadrature avoids compiling three nested adaptive integrators.
-# These orders resolve all exponents, momenta, and directions checked below.
-function gaussian_fourier_integral(b, k, θk, φk)
-  radial_nodes, radial_weights = QuadGK.gauss(192)
-  polar_nodes, polar_weights = QuadGK.gauss(64)
-  azimuthal_nodes, azimuthal_weights = QuadGK.gauss(64)
-  integral = 0.0im
-  for (x, wx) in zip(radial_nodes, radial_weights)
-    # Map [-1, 1] to [0, ∞) with r = t / (1 - t), t = (x + 1) / 2.
-    t = (x + 1) / 2
-    r = t / (1 - t)
-    radial_factor = wx / (2 * (1 - t)^2) * TwoBody.φ(b, r) * r^2
-    for (y, wy) in zip(polar_nodes, polar_weights)
-      θ = π * (y + 1) / 2
-      polar_factor = wy * π / 2 * sin(θ)
-      for (z, wz) in zip(azimuthal_nodes, azimuthal_weights)
-        φ = π * (z + 1)
-        integral += radial_factor * polar_factor * wz * π * TwoBody.expikr(k, θk, φk, r, θ, φ)
-      end
-    end
-  end
-  return abs((2π)^(-3/2) * integral)
+# For a spherical Gaussian, angular integration gives 4π j₀(kr).
+# Keep the radial integral numerical and compare it with the analytic transform.
+function gaussian_fourier_integral(b, k)
+  integral, _ = quadgk(
+    r -> r^2 * TwoBody.φ(b, r) * sphericalbesselj(0, k * r),
+    0, Inf; atol=1e-9, rtol=1e-8,
+  )
+  return sqrt(2 / π) * integral
 end
 
 @testset "Basis.jl" begin
@@ -89,22 +75,34 @@ end
     @test_throws ArgumentError ContractedBasis([1.0], Any["invalid"])
   end
 
-  println("φ(r) = exp(-ar²)")
-  println("φ(k) = exp(-k²/4a) / (2a)^(3/2)")
-  println("φ(k) = 1/√2π³ ∫ φ(r) eⁱᵏʳ r²sin(θ)drdθdφ")
-  println("    a\t    k\t θk\t φk\tnumerical  \tanalytical")
-  for b in BS.basis
-    a = b.a
-    for k in [0.0, 3.0, 5.0]
-    for θk in [0.0, 0.5]
-    for φk in [0.0, 1.0]
-      numerical = gaussian_fourier_integral(b, k, θk, φk)
+  @testset "Gaussian Fourier transform" begin
+    println("φ(k) = √(2/π) ∫ r² φ(r) j₀(kr) dr")
+    println("    a\t    k\tnumerical  \tanalytical")
+    for b in BS.basis, k in [0.0, 3.0, 5.0]
+      a = b.a
+      numerical = gaussian_fourier_integral(b, k)
       analytical = exp(-k^2/4/a) / (2*a)^(3/2)
       acceptance = abs(analytical)<1e-5 ? isapprox(analytical, numerical, atol=1e-2) : isapprox(analytical, numerical, rtol=1e-2)
       @test acceptance
-      @printf("%5.2f\t%5.2f\t%.1f\t%.1f\t%.9f\t%.9f\t%s\n", a, k, θk, φk, numerical, analytical, acceptance ? "✔" :  "✗")
+      @printf("%5.2f\t%5.2f\t%.9f\t%.9f\t%s\n", a, k, numerical, analytical, acceptance ? "✔" :  "✗")
     end
-    end
+  end
+
+  @testset "expikr" begin
+    # Include the original momentum directions, Cartesian axes, and an oblique
+    # spatial direction. Compare the complex phase, not only its magnitude.
+    momentum_directions = (
+      (0.0, 0.0), (0.0, 1.0), (0.5, 0.0), (0.5, 1.0),
+      (π / 2, π / 2), (π, 0.0),
+    )
+    spatial_directions = (
+      (0.0, 0.0), (π / 2, 0.0), (π / 2, π / 2), (π, 0.0), (1.2, 2.3),
+    )
+    for k in (0.0, 3.0, 5.0), r in (0.0, 0.3, 2.0)
+      for (θk, φk) in momentum_directions, (θr, φr) in spatial_directions
+        cosγ = cos(θk) * cos(θr) + sin(θk) * sin(θr) * cos(φk - φr)
+        @test TwoBody.expikr(k, θk, φk, r, θr, φr) ≈ cis(k * r * cosγ) atol=1e-12 rtol=1e-12
+      end
     end
   end
 


### PR DESCRIPTION
Closes #76.
Closes #69.

The CI workflow ran tests without uploading coverage, TagBot failed with HTTP 403 because its token only had read permissions, and CompatHelper was disabled by GitHub due to inactivity. The basis tests also spent over ten minutes compiling nested numerical quadrature on Julia 1.12.

- Restore coverage processing for `src` and `ext` on Julia 1.10 and upload `lcov.info` with Codecov v7. Use GitHub OIDC for repository builds excluding Dependabot, and fail on upload errors there. Fork and Dependabot runs attempt tokenless uploads; only their upload step is nonfatal, while test and coverage-generation failures still fail CI.
- Update checkout to v7, setup-julia to v3, upload-artifact to v7, and the Julia cache action to v3. Preserve the Julia 1.10/1.12 matrix, core-installation checks, and documentation checks.
- Grant TagBot release/issue permissions and changelog access. Set up Julia explicitly for CompatHelper, install and run it in the same temporary project environment, and grant dependency-PR permissions. Add bounded timeouts to maintenance, core, documentation, and formatting jobs.
- Add a manual-only Runic workflow that saves a downloadable patch only when Runic fails with actual formatting changes, and document workflow operation and setup.
- Follow #69's spherical-Bessel approach: analytically integrate the angular coordinates and evaluate `sqrt(2/pi) * integral(r^2 * phi(r) * sphericalbesselj(0, k*r), r=0..Inf)` numerically. All four Gaussian exponents, three momenta, analytic references, and acceptance tolerances are retained. The 12 radial integrals use adaptive error control instead of selecting a fixed three-dimensional grid.
- Test `expikr` independently against `cis(k*r*cosγ)` in 270 cases, including the original momentum directions, zero magnitudes, Cartesian axes, and an oblique spatial direction. Comparing the full complex phase catches sign errors that an absolute-value comparison could miss. Production code is unchanged.

Validation:

- `git diff --check` passed; all four workflows passed actionlint 1.7.12.
- [Final CI run after workflow review](https://github.com/JuliaFewBody/TwoBody.jl/actions/runs/34050215404) passed all 788 tests on both Julia 1.10 and 1.12, core installation, documentation build/deployment and doctests, and Codecov upload. The `codecov/patch` check passed.
- In that run, the Julia 1.10/1.12 jobs took 2m56s/3m04s. Documentation took 14m41s, including 599 seconds precompiling 401 dependencies; this is separate from the historical test timings below.
- The Runic patch script was checked against clean and modified fixture repositories: empty patches are suppressed, and generated patches apply successfully.
- Local Julia 1.12.3: all 336 basis tests passed in 2.4 seconds; the maximum absolute error over the 12 radial Fourier integrals was 3.8e-14.

Updated test timings, comparing [the original nested quadrature](https://github.com/JuliaFewBody/TwoBody.jl/actions/runs/34043224173) with [the radial-test CI run](https://github.com/JuliaFewBody/TwoBody.jl/actions/runs/34045749718):

| Test | Julia 1.10 before | Julia 1.10 after | Julia 1.12 before | Julia 1.12 after |
| --- | ---: | ---: | ---: | ---: |
| Basis | 79.8 s | 3.0 s | 636.3 s | 2.7 s |
| QTT | 32.3 s | 35.6 s | 43.5 s | 43.4 s |
| VNN | 37.5 s | 40.9 s | 36.5 s | 34.4 s |
| Rayleigh-Ritz | 12.1 s | 13.1 s | 18.8 s | 9.7 s |
| GEM | 9.5 s | 10.6 s | 15.9 s | 7.3 s |
| Full test suite | 204.8 s | 141.0 s | 791.7 s | 134.0 s |

The entire Julia 1.12 test job decreased from 19m21s to 2m56s, including the benefit of reused dependency caches. Job-level improvements should not be attributed entirely to the test change. TagBot, CompatHelper, and Runic were statically validated but not dispatched; fork and Dependabot execution contexts were not exercised in CI. The default-branch coverage baseline will be created after merge.

Maintainer setup: re-enable CompatHelper if still inactive and enable Settings > Actions > General > Allow GitHub Actions to create and approve pull requests. No `CODECOV_TOKEN` is required. Organization-wide token authentication can remain enabled: [Codecov documents tokenless uploads for public fork branches](https://docs.codecov.com/docs/codecov-tokens#commits-on-unprotected-branches). GitHub releases for commits that modify workflows may still need manual creation or a PAT with workflow scope, as documented by TagBot; the existing `DOCUMENTER_KEY` remains in use.

This pull request was developed with assistance from Codex using GPT-6 Astra with High reasoning effort.