### PR TITLE
Fix intermittent documentation math rendering

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,7 +2,6 @@
 Antique = "be6e5d0e-34a5-4c8f-af83-e1b5389203d8"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-DocumenterMermaid = "a078cd44-4d9c-4618-b545-3ab9d77f9177"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,6 @@ import Optimisers
 import TensorTrainNumerics
 import Zygote
 using Documenter
-using DocumenterMermaid
 
 DocMeta.setdocmeta!(TwoBody, :DocTestSetup, :(using TwoBody); recursive=true)
 

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -132,7 +132,8 @@ To register a release in the [General](https://github.com/JuliaRegistries/Genera
 
 `src/TwoBody.jl` defines the `TwoBody` module and includes the source files in dependency order. `Hamiltonian.jl` defines the shared problem representation. `Basis.jl` supports the Rayleigh–Ritz implementation, and `FDM.jl` supplies the discretization used by the variational neural-network method. The solver files extend `solve` for their respective method types.
 
-```mermaid
+```@raw html
+<pre class="mermaid">
 ---
 config:
   layout: elk
@@ -150,8 +151,16 @@ flowchart TD
   T["TwoBody.jl"]
 
   H --> D
-  H --> R & F & Q & N & V
+  H --> R &amp; F &amp; Q &amp; N &amp; V
   B --> R
   F --> N
-  H & D & B & R & F & Q & N & V --> T
+  H &amp; D &amp; B &amp; R &amp; F &amp; Q &amp; N &amp; V --> T
+</pre>
+<script type="module">
+  // Use the pinned ESM conversion on this page only. The dist bundle's FastDOM
+  // dependency registers anonymous AMD modules and breaks Documenter's math loader.
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.17.2/+esm';
+  mermaid.initialize({ startOnLoad: false, theme: "neutral" });
+  await mermaid.run({ querySelector: '.mermaid' });
+</script>
 ```


### PR DESCRIPTION
Equations could remain as raw TeX until a reload because DocumenterMermaid injected an unpinned Mermaid bundle into every page. Its FastDOM dependency registers anonymous AMD modules with Documenter's RequireJS, producing `Mismatched anonymous define()` errors and interrupting KaTeX loading.

Remove DocumenterMermaid and load Mermaid only in the developer guide's architecture diagram. Pin Mermaid to 11.17.2 and use jsDelivr's ESM conversion, which exports FastDOM without registering anonymous AMD modules. Render the existing diagram explicitly after initialization.

Validation:
- Reproduced the published site's failure and the loading-order conflict in a minimal page; the fixed ESM loader passed repeated loading-order checks.
- Completed a full local documentation build with Julia 1.12.3 and Documenter 1.19.0.
- Checked all 12 generated pages over local HTTP: 365 rendered equations, no unrendered display equations or KaTeX rendering errors, and no new JavaScript errors in the final pass.
- Verified the architecture diagram's 9 nodes and 16 edges, plus sidebar navigation without reloading.
- `git diff --check origin/main...HEAD` passes.

Closes #80

---
This pull request was developed with assistance from Codex using GPT-6 Astra with High reasoning effort.